### PR TITLE
Untitled

### DIFF
--- a/src/org/zeromq/ZMQQueue.java
+++ b/src/org/zeromq/ZMQQueue.java
@@ -44,7 +44,7 @@ public class ZMQQueue implements Runnable {
         while (!Thread.currentThread().isInterrupted()) {
             try {
                 // wait while there are either requests or replies to process
-                if (poller.poll(250) < 1) {
+                if (poller.poll(-1) < 1) {
                     continue;
                 }
 


### PR DESCRIPTION
When using ZMQQueue, my application was consuming 100% CPU time. This patches the issue by changing ZMQQueue to not busy wait. See:

http://lists.zeromq.org/pipermail/zeromq-dev/2011-February/009411.html

For the relevant discussion & suggestion.
