### PR TITLE
Added SHELL variable to Makefile.am.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,6 @@
+SHELL = /bin/sh
+
 ACLOCAL_AMFLAGS = -I config
 
 SUBDIRS = src perf
 DIST_SUBDIRS = src perf
-


### PR DESCRIPTION
The MAKEFILE uses the user's default shell if this variable is not set and may results errors.  Example: 'No rule to make target __' if the user's shell is set to zsh.
