### PR TITLE
allow packaging native JNI libraries in JAR file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,19 @@
 		<sourceDirectory>src</sourceDirectory>
 		<testSourceDirectory>test/src</testSourceDirectory>
 
+		<resources>
+			<resource>
+				<filtering>false</filtering>
+				<targetPath>NATIVE/${os.arch}/${os.name}</targetPath>
+				<directory>${basedir}/src/.libs</directory>
+				<includes>
+					<include>libjzmq.so</include>
+					<include>libjzmq.dylib</include>
+					<include>libjzmq.dll</include>
+				</includes>
+			</resource>
+		</resources>
+
 		<plugins>
 
 			<plugin>

--- a/src/org/zeromq/App.java
+++ b/src/org/zeromq/App.java
@@ -1,6 +1,13 @@
 package org.zeromq;
 
-import org.zeromq.ZMQ;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 /**
  * Simple App to display version information about jzmq.
@@ -13,17 +20,102 @@ public class App {
 		final Package p = App.class.getPackage();
 		final String appname = p.getSpecificationTitle();
 		final String versionMaven = p.getSpecificationVersion();
-		final String[] version = p.getImplementationVersion().split(" ", 2);
+		String[] version = new String[] {"", ""};
+		if (p.getImplementationVersion() != null) {
+			version = p.getImplementationVersion().split(" ", 2);
+		}
 
-		final int major = ZMQ.version_major();
-		final int minor = ZMQ.version_minor();
-		final int patch = ZMQ.version_patch();
+		String zmqVersion = null;
+		String libzmqLocation = null;
+		
+		try {
 
-		System.out.printf("%s version:    %s.%s.%s%n", "ZeroMQ", major, minor, patch);
-		System.out.printf("%s version:      %s%n", appname, versionMaven);
-		System.out.printf("%s build time:   %s%n", appname, version[1]);
-		System.out.printf("%s build commit: %s%n", appname, version[0]);
+			final int major = ZMQ.version_major();
+			final int minor = ZMQ.version_minor();
+			final int patch = ZMQ.version_patch();
+			zmqVersion = major + "." + minor + "." + patch;
+			libzmqLocation = ZMQ.LIB_LOCATION;
+	
+		} catch (Throwable x) {
+			zmqVersion = "ERROR! " + x.getMessage();
+			libzmqLocation = "ERROR! Not found.";
+		}
+		
+		final String fmt = "%-7.7s %-15.15s %s%n";
+		
+		System.out.printf(fmt, "ZeroMQ", "version:", zmqVersion);
+		System.out.printf(fmt, appname, "version:", versionMaven);
+		System.out.printf(fmt, appname, "build time:", version[1]);
+		System.out.printf(fmt, appname, "build commit:", version[0]);
+		System.out.printf(fmt, "JNI lib", "location:", libzmqLocation);
+		System.out.printf(fmt, "current", "platform:", 
+				System.getProperty("os.arch") + "/" + System.getProperty("os.name"));
 
+		listEmbeddedBinaries();
+		
+	}
+	
+	private static void listEmbeddedBinaries() {
+		
+		System.out.println("--- list of embedded JNI libraries ---");
+		
+		final Collection<String> files = catalogClasspath();
+		
+		for (final String file : files) {
+			if (file.startsWith("NATIVE")) {
+				System.out.println(file);
+			}
+		}
+		
+	}
+	
+	private static Collection<String> catalogClasspath() {
+		
+		final List<String> files = new ArrayList<String>();		
+		final String[] classpath = System.getProperty("java.class.path", "").split(File.pathSeparator);
+		
+		for (final String path : classpath) {
+			final File tmp = new File(path);
+			if (tmp.isFile() && path.toLowerCase().endsWith(".jar")) {
+				catalogArchive(tmp, files);
+			} else if (tmp.isDirectory()) {
+				final int len = tmp.getPath().length() +1;
+				catalogFiles(len, tmp, files);
+			}
+		}
+		
+		return files;
+		
+	}
+	
+	private static void catalogArchive(final File jarfile, final Collection<String> files) {
+		
+		try {
+		
+			final JarFile j = new JarFile(jarfile);
+			final Enumeration<JarEntry> e = j.entries();
+			while (e.hasMoreElements()) {
+				final JarEntry entry = e.nextElement();
+				if (!entry.isDirectory()) {
+					files.add(entry.getName());
+				}
+			}
+	
+		} catch (IOException x) {
+			System.err.println(x.toString());
+		}
+		
+	}
+	
+	private static void catalogFiles(final int prefixlen, final File root, final Collection<String> files) {
+		final File[] ff = root.listFiles();
+		for (final File f : ff) {
+			if (f.isDirectory()) {
+				catalogFiles(prefixlen, f, files);
+			} else {
+				files.add(f.getPath().substring(prefixlen));
+			}
+		}
 	}
 
 }

--- a/src/org/zeromq/ZMQ.java
+++ b/src/org/zeromq/ZMQ.java
@@ -18,6 +18,13 @@
 */
 package org.zeromq;
 
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
 import java.util.LinkedList;
 
 /**
@@ -27,9 +34,71 @@ import java.util.LinkedList;
  * 
  */
 public class ZMQ {
-    static {
-        System.loadLibrary ("jzmq");
-    }
+	
+	static final String LIB_LOCATION;
+
+	static {
+
+		boolean usedEmbeddedLibrary = false;
+
+		// attempt to locate embedded native library within JAR at following location:
+		// /NATIVE/${os.arch}/${os.name}/libjzmq.[so|dylib|dll]
+		String[] allowedExtensions = new String[] {"so", "dylib", "dll"};
+		StringBuilder url = new StringBuilder();
+		url.append("/NATIVE/");
+		url.append(System.getProperty("os.arch"));
+		url.append("/");
+		url.append(System.getProperty("os.name"));
+		url.append("/libjzmq.");    	
+		URL nativeLibraryUrl = null;
+		// loop through extensions, stopping after finding first one
+		for (String ext : allowedExtensions) {
+			nativeLibraryUrl = ZMQ.class.getResource(url.toString() + ext);
+			if (nativeLibraryUrl != null)
+				break;
+		}
+
+		if (nativeLibraryUrl != null) {
+
+			// native library found within JAR, extract and load
+
+			try {
+
+				final File libfile = File.createTempFile("libjzmq-", ".lib");
+				libfile.deleteOnExit(); // just in case
+
+				final InputStream in = nativeLibraryUrl.openStream();
+				final OutputStream out = new BufferedOutputStream(new FileOutputStream(libfile));
+
+				int len = 0;
+				byte[] buffer = new byte[8192];
+				while ((len = in.read(buffer)) > -1)
+					out.write(buffer, 0, len);
+				out.close();
+				in.close();
+
+				System.load(libfile.getAbsolutePath());
+				
+				libfile.delete();
+
+				usedEmbeddedLibrary = true;
+
+			} catch (IOException x) {
+				// mission failed, do nothing
+			}
+
+
+		} // nativeLibraryUrl exists
+
+		// if no embedded native library, revert to loading from java.library.path
+		if (!usedEmbeddedLibrary)
+			System.loadLibrary ("jzmq");
+
+		// set LIB_LOCATION
+		LIB_LOCATION = (usedEmbeddedLibrary ? "embedded" : "java.library.path");
+		
+		
+	}
 
     // Values for flags in Socket's send and recv functions.
     /**


### PR DESCRIPTION
- Modified Maven POM to include the JNI library within the JAR file. 
- Modified ZMQ static initializer to extract the native library, if present, to a temp file and then load it.
- Modified App to display current platform (arch/os) and list of embedded libraries.

These changes make it unnecessary to manually set the java.library.path.
Additionally, it will be possible to build JAR files that contain the native libraries for multiple platforms.

Maven does not require the JNI library to be present to build the JAR file, however, if the library is present it will be packaged into the JAR.

To build a JAR without the native library:
- ./autogen.sh
- ./configure
- make
- make install
- make clean
- mvn clean install

To build a JAR with the embedded native library:
- ./autogen.sh
- ./configure
- make
- mvn clean install
