### PR TITLE
Error handling for send / recv

### DIFF
--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -378,7 +378,7 @@ JNIEXPORT jboolean JNICALL Java_org_zeromq_ZMQ_00024Socket_send (JNIEnv *env,
 #endif
     err = zmq_errno();
         
-    if (rc != 0 && err == EAGAIN) {
+    if (rc < 0 && err == EAGAIN) {
         rc = zmq_msg_close (&message);
         err = zmq_errno();
         if (rc != 0) {
@@ -388,7 +388,7 @@ JNIEXPORT jboolean JNICALL Java_org_zeromq_ZMQ_00024Socket_send (JNIEnv *env,
         return JNI_FALSE;
     }
     
-    if (rc != 0) {
+    if (rc < 0) {
         raise_exception (env, err);
         rc = zmq_msg_close (&message);
         err = zmq_errno();
@@ -432,7 +432,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_zeromq_ZMQ_00024Socket_recv (JNIEnv *env,
     rc = zmq_recv (s, &message, flags);
 #endif
     err = zmq_errno();
-    if (rc != 0 && err == EAGAIN) {
+    if (rc < 0 && err == EAGAIN) {
         rc = zmq_msg_close (&message);
         err = zmq_errno();
         if (rc != 0) {
@@ -442,7 +442,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_zeromq_ZMQ_00024Socket_recv (JNIEnv *env,
         return NULL;
     }
 
-    if (rc != 0) {
+    if (rc < 0) {
         raise_exception (env, err);
         rc = zmq_msg_close (&message);
         err = zmq_errno();

--- a/test/src/org/zeromq/ZMQTest.java
+++ b/test/src/org/zeromq/ZMQTest.java
@@ -1,6 +1,8 @@
 package org.zeromq;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -32,6 +34,31 @@ public class ZMQTest
   {
     assertEquals ( ZMQ.getMajorVersion () + "." + ZMQ.getMinorVersion () + "." + ZMQ.getPatchVersion (),
                    ZMQ.getVersionString () );
+  }
+  
+  @Test
+  public void testReqRep ()
+  {
+	  	ZMQ.Context context = ZMQ.context(1);
+	  
+		ZMQ.Socket in = context.socket(ZMQ.REQ);
+		in.bind("inproc://reqrep");
+
+		ZMQ.Socket out = context.socket(ZMQ.REP);
+		out.connect("inproc://reqrep");
+	  
+		for (int i = 0; i < 10; i++) {
+			byte[] req = ("request" + i).getBytes();
+			byte[] rep = ("reply" + i).getBytes();
+
+			assertTrue(in.send(req, 0));
+			byte[] reqTmp = out.recv(0);
+			assertArrayEquals(req, reqTmp);
+			
+			assertTrue(out.send(rep, 0));
+			byte[] repTmp = in.recv(0);
+			assertArrayEquals(rep, repTmp);
+		}		
   }
 
 }


### PR DESCRIPTION
It looks like the error handling behavior has to change for the 0MQ 3.x line.

Given how 2.x and 3.x currently work, I believe this can support both with the same code.
