### PR TITLE
cleaned up javadoc of new recv(...) function

### DIFF
--- a/src/org/zeromq/ZMQ.java
+++ b/src/org/zeromq/ZMQ.java
@@ -884,7 +884,7 @@ public class ZMQ {
          *            the message will be truncated.
          * @param flags
          *            the flags to apply to the receive operation.
-         * @return the message received, as an array of bytes; null on error.
+         * @return the number of bytes read, -1 on error
          */
         public native int recv (byte[] buffer, int offset, int len, int flags);
 


### PR DESCRIPTION
incorrectly had the original byte[] returning comment
