### PR TITLE
getLongSockOpt fails for several options under 0mq 3.x

### DIFF
--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -110,12 +110,12 @@ JNIEXPORT jlong JNICALL Java_org_zeromq_ZMQ_00024Socket_getLongSockopt (JNIEnv *
     case ZMQ_HWM:
     case ZMQ_SWAP:
     case ZMQ_MCAST_LOOP:
+#endif
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(2,1,0)
     case ZMQ_TYPE:
     case ZMQ_FD:
     case ZMQ_EVENTS:
     case ZMQ_LINGER:
-#endif
 #endif
     case ZMQ_AFFINITY:
     case ZMQ_RATE:


### PR DESCRIPTION
The following options are unavailable due to an error in the version check in getLongSockopt():
- ZMQ_TYPE
- ZMQ_FD
- ZMQ_EVENTS
- ZMQ_LINGER

This pull request corrects the version check to make these options available once again.
