### PR TITLE
Fixed setLongSockOpt() not permitting LINGER for ZMQ 3.0.

### DIFF
--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -206,9 +206,9 @@ JNIEXPORT void JNICALL Java_org_zeromq_ZMQ_00024Socket_setLongSockopt (JNIEnv *e
     case ZMQ_HWM:
     case ZMQ_SWAP:
     case ZMQ_MCAST_LOOP:
+#endif
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(2,1,0)
     case ZMQ_LINGER:
-#endif
 #endif
     case ZMQ_AFFINITY:
     case ZMQ_RATE:


### PR DESCRIPTION
setLongSockOpt() appears to have a merge error in its IFDEFs that prevents several socket options from being set under ZMQ 3.x

This is the same issue as https://github.com/zeromq/jzmq/pull/66, but on setLongSockOpt, not getLongSockOpt.
