### PR TITLE
Align version number with that of 0MQ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.zeromq</groupId>
 	<artifactId>jzmq</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>jzmq</name>
 


### PR DESCRIPTION
It's helpful for language bindings to adopt the same major and minor version numbers as the library it's built for. Fixes that don't change the API compatibility can be made using the right-most revision number.
