### PR TITLE
Alter shadow ZContext testing to reflect usage

### DIFF
--- a/test/src/org/zeromq/ZContextTest.java
+++ b/test/src/org/zeromq/ZContextTest.java
@@ -81,14 +81,15 @@ public class ZContextTest {
 		assertEquals(1, ctx.getSockets().size());
 
 		ZContext shadowCtx = ZContext.shadow(ctx);
+		shadowCtx.setMain(false);
 		assertEquals(0, shadowCtx.getSockets().size());
 		@SuppressWarnings("unused")
 		Socket s1 = shadowCtx.createSocket(ZMQ.SUB);
 		assertEquals(1, shadowCtx.getSockets().size());
 		assertEquals(1, ctx.getSockets().size());
 
-		ctx.destroy();
 		shadowCtx.destroy();
+		ctx.destroy();
 	}
 	
 	


### PR DESCRIPTION
zmq_term() will not return until all sockets created by it are also zmq_close()'d.

Change regression test to work within this constraint.
