### PR TITLE
Add missing ZMsg.newStringMessage method

### DIFF
--- a/src/org/zeromq/ZMsg.java
+++ b/src/org/zeromq/ZMsg.java
@@ -277,6 +277,22 @@ public class ZMsg implements Iterable<ZFrame>, Deque<ZFrame>{
 		}
 	}
 
+    /**
+     * Create a new ZMsg from one or more Strings
+     *
+     * @param strings
+     *      Strings to add as frames.
+     * @return
+     *      ZMsg object
+     */
+    public static ZMsg newStringMsg(String... strings) {
+        ZMsg msg = new ZMsg();
+        for (String data : strings) {
+            msg.addString(data);
+        }
+        return msg;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/test/src/org/zeromq/ZMsgTest.java
+++ b/test/src/org/zeromq/ZMsgTest.java
@@ -186,4 +186,22 @@ public class ZMsgTest {
 			assertTrue(false);
 		}
 	}
+
+    @Test
+    public void testNewStringMessage() {
+        // A single string => frame
+        ZMsg msg = ZMsg.newStringMsg("Foo");
+        assertEquals(1, msg.size());
+        assertTrue(msg.getFirst().streq("Foo"));
+
+        // Multiple strings => frames
+        ZMsg msg2 = ZMsg.newStringMsg("Foo", "Bar", "Baz");
+        assertEquals(3, msg2.size());
+        assertTrue(msg2.getFirst().streq("Foo"));
+        assertTrue(msg2.getLast().streq("Baz"));
+
+        // Empty message (Not very useful)
+        ZMsg msg3 = ZMsg.newStringMsg();
+        assertTrue(msg3.isEmpty());
+    }
 }


### PR DESCRIPTION
This static method is referred to in the javadoc for ZMsg, but not implemented. So I added it. :)
