### PR TITLE
Version check for testXPUBSUB

### DIFF
--- a/test/src/org/zeromq/ZMQTest.java
+++ b/test/src/org/zeromq/ZMQTest.java
@@ -64,6 +64,11 @@ public class ZMQTest
     @Test
     public void testXPUBSUB ()
     {
+        if (ZMQ.getFullVersion() <  ZMQ.make_version(3, 0, 0)) {
+          // Can only test XPUB on ZMQ >= of 3.0
+          return;
+        }
+
         ZMQ.Context context = ZMQ.context(1);
 
         ZMQ.Socket pub = context.socket(ZMQ.XPUB);


### PR DESCRIPTION
Added a version check to make sure the version of zeromq is at least
3.0.0 or greater for testing the XPUB so that it does not cause the
test to hang.
