### PR TITLE
lowered version requirement for SNDTIMEO and RCVTIMEO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ debian/jzmq.substvars
 debian/jzmq/
 debian/tmp/
 .DS_Store
+*.iml
+config/
+build/

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -106,12 +106,14 @@ JNIEXPORT jlong JNICALL Java_org_zeromq_ZMQ_00024Socket_getLongSockopt (JNIEnv *
     case ZMQ_SNDHWM:
     case ZMQ_RCVHWM:
     case ZMQ_MULTICAST_HOPS:
-    case ZMQ_RCVTIMEO:
-    case ZMQ_SNDTIMEO:
 #else
     case ZMQ_HWM:
     case ZMQ_SWAP:
     case ZMQ_MCAST_LOOP:
+#endif
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(2,2,0)
+    case ZMQ_RCVTIMEO:
+    case ZMQ_SNDTIMEO:
 #endif
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(2,1,10)
     case ZMQ_RECONNECT_IVL:
@@ -207,12 +209,14 @@ JNIEXPORT void JNICALL Java_org_zeromq_ZMQ_00024Socket_setLongSockopt (JNIEnv *e
     case ZMQ_SNDHWM:
     case ZMQ_RCVHWM:
     case ZMQ_MULTICAST_HOPS:
-    case ZMQ_RCVTIMEO:
-    case ZMQ_SNDTIMEO:
 #else
     case ZMQ_HWM:
     case ZMQ_SWAP:
     case ZMQ_MCAST_LOOP:
+#endif
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(2,2,0)
+    case ZMQ_RCVTIMEO:
+    case ZMQ_SNDTIMEO:
 #endif
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(2,1,10)
     case ZMQ_RECONNECT_IVL:
@@ -235,10 +239,16 @@ JNIEXPORT void JNICALL Java_org_zeromq_ZMQ_00024Socket_setLongSockopt (JNIEnv *e
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(2,1,0)
             if(
                 (option == ZMQ_LINGER)
+#endif
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(2,1,10)
                 || (option == ZMQ_RECONNECT_IVL)
                 || (option == ZMQ_RECONNECT_IVL_MAX)
 #endif
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(2,2,0)
+                || (option == ZMQ_SNDTIMEO)
+                || (option == ZMQ_RCVTIMEO)
+#endif
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(2,1,0)    
             ) {
                 int ival = (int) optval;
                 size_t optvallen = sizeof(ival);

--- a/src/org/zeromq/ZMQ.java
+++ b/src/org/zeromq/ZMQ.java
@@ -582,8 +582,8 @@ public class ZMQ {
          * 
          * @param timeout
          */
-        public void setReceiveTimeOut (long timeout) {
-            if (ZMQ.version_full() < ZMQ.make_version(3, 0, 0))
+        public void setReceiveTimeOut (int timeout) {
+            if (ZMQ.version_full() < ZMQ.make_version(2, 2, 0))
                 return;
 
             setLongSockopt (RCVTIMEO, timeout);
@@ -594,10 +594,10 @@ public class ZMQ {
          * 
          * @return the Receive Timeout
          */
-        public long getReceiveTimeOut () {
-			if (ZMQ.version_full() < ZMQ.make_version(3, 0, 0))
+        public int getReceiveTimeOut () {
+			if (ZMQ.version_full() < ZMQ.make_version(2, 2, 0))
                 return -1;
-            return getLongSockopt (RCVTIMEO);
+            return (int) getLongSockopt (RCVTIMEO);
         }
 
         /**
@@ -609,8 +609,8 @@ public class ZMQ {
          * 
          * @param timeout
          */
-        public void setSendTimeOut (long timeout) {
-            if (ZMQ.version_full() < ZMQ.make_version(3, 0, 0))
+        public void setSendTimeOut (int timeout) {
+            if (ZMQ.version_full() < ZMQ.make_version(2, 2, 0))
                 return;
 
             setLongSockopt (SNDTIMEO, timeout);
@@ -621,10 +621,10 @@ public class ZMQ {
          * 
          * @return the Send Timeout.
          */
-        public long getSendTimeOut () {
-			if (ZMQ.version_full() < ZMQ.make_version(3, 0, 0))
+        public int getSendTimeOut () {
+			if (ZMQ.version_full() < ZMQ.make_version(2, 2, 0))
                 return -1;
-            return getLongSockopt (SNDTIMEO);
+            return (int) getLongSockopt (SNDTIMEO);
         }
 
         /**


### PR DESCRIPTION
libzmq released 2.2.0 with the SNDTIMEO and RCVTIMEO socket options
