### PR TITLE
Update MSVC project to add the new Java classes

### DIFF
--- a/builds/msvc/jzmq/jzmq.vcproj
+++ b/builds/msvc/jzmq/jzmq.vcproj
@@ -25,7 +25,7 @@
 			<Tool
 				Name="VCPreBuildEventTool"
 				Description="Compiling Java classes"
-				CommandLine="copy ..\config.hpp ..\..\..\src&#x0D;&#x0A;javac ..\..\..\src\org\zeromq\ZMQ.java ..\..\..\src\org\zeromq\ZMQException.java ..\..\..\src\org\zeromq\ZMQForwarder.java ..\..\..\src\org\zeromq\ZMQQueue.java ..\..\..\src\org\zeromq\ZMQStreamer.java ..\..\..\src\org\zeromq\EmbeddedLibraryTools.java ..\..\..\src\org\zeromq\App.java&#x0D;&#x0A;"
+				CommandLine="copy ..\config.hpp ..\..\..\src&#x0D;&#x0A;javac ..\..\..\src\org\zeromq\ZMQ.java ..\..\..\src\org\zeromq\ZMQException.java ..\..\..\src\org\zeromq\ZMQForwarder.java ..\..\..\src\org\zeromq\ZMQQueue.java ..\..\..\src\org\zeromq\ZMQStreamer.java ..\..\..\src\org\zeromq\EmbeddedLibraryTools.java ..\..\..\src\org\zeromq\App.java ..\..\..\src\org\zeromq\ZContext.java ..\..\..\src\org\zeromq\ZDispatcher.java ..\..\..\src\org\zeromq\ZFrame.java ..\..\..\src\org\zeromq\ZMsg.java&#x0D;&#x0A;"
 			/>
 			<Tool
 				Name="VCCustomBuildTool"
@@ -99,7 +99,7 @@
 			<Tool
 				Name="VCPreBuildEventTool"
 				Description="Compiling Java classes"
-				CommandLine="copy ..\config.hpp ..\..\..\src&#x0D;&#x0A;javac ..\..\..\src\org\zeromq\ZMQ.java ..\..\..\src\org\zeromq\ZMQException.java ..\..\..\src\org\zeromq\ZMQForwarder.java ..\..\..\src\org\zeromq\ZMQQueue.java ..\..\..\src\org\zeromq\ZMQStreamer.java ..\..\..\src\org\zeromq\EmbeddedLibraryTools.java ..\..\..\src\org\zeromq\App.java&#x0D;&#x0A;"
+				CommandLine="copy ..\config.hpp ..\..\..\src&#x0D;&#x0A;javac ..\..\..\src\org\zeromq\ZMQ.java ..\..\..\src\org\zeromq\ZMQException.java ..\..\..\src\org\zeromq\ZMQForwarder.java ..\..\..\src\org\zeromq\ZMQQueue.java ..\..\..\src\org\zeromq\ZMQStreamer.java ..\..\..\src\org\zeromq\EmbeddedLibraryTools.java ..\..\..\src\org\zeromq\App.java ..\..\..\src\org\zeromq\ZContext.java ..\..\..\src\org\zeromq\ZDispatcher.java ..\..\..\src\org\zeromq\ZFrame.java ..\..\..\src\org\zeromq\ZMsg.java&#x0D;&#x0A;"
 			/>
 			<Tool
 				Name="VCCustomBuildTool"


### PR DESCRIPTION
Java classes ZContext, ZDispatcher, ZFrame and ZMsg were not included into MSVC project, therefore they didn't appear in the resulting zmq.jar. This trivial patch adds them to the MSVC project.
