### PR TITLE
make native library search ignore Windows version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,23 @@
 		<maven-source-plugin.version>2.1.2</maven-source-plugin.version>
 
 		<junit.version>4.8.2</junit.version>
+
+		<native.os>${os.name}</native.os>
 	</properties>
+
+	<profiles>
+		<profile>
+			<id>Windows</id>
+			<activation>
+				<os>
+					<family>windows</family>
+				</os>
+			</activation>
+			<properties>
+				<native.os>Windows</native.os>
+			</properties>
+		</profile>
+	</profiles>
 
 	<dependencies>
 		<dependency>
@@ -63,7 +79,7 @@
 		<resources>
 			<resource>
 				<filtering>false</filtering>
-				<targetPath>NATIVE/${os.arch}/${os.name}</targetPath>
+				<targetPath>NATIVE/${os.arch}/${native.os}</targetPath>
 				<directory>${basedir}/src/.libs</directory>
 				<includes>
 					<include>libjzmq.so</include>

--- a/src/org/zeromq/EmbeddedLibraryTools.java
+++ b/src/org/zeromq/EmbeddedLibraryTools.java
@@ -23,7 +23,12 @@ public class EmbeddedLibraryTools {
 	}
 	
 	public static String getCurrentPlatformIdentifier() {
-		return System.getProperty("os.arch") + "/" + System.getProperty("os.name");
+		String osName = System.getProperty("os.name");
+		if (osName.toLowerCase().indexOf("windows") > -1) {
+			osName = "Windows";
+		}
+		
+		return System.getProperty("os.arch") + "/" + osName;
 	}
 	
 	public static Collection<String> getEmbeddedLibraryList() {


### PR DESCRIPTION
This fixes #57 by replacing any os.name containing "Windows" with the simple string "Windows" in getCurrentPlatformIdentifier() and dropping the Windows version from the JAR NATIVE/ path.
