### PR TITLE
Allow interfacing with other languages/bindings

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -62,6 +62,27 @@ JNIEXPORT void JNICALL Java_org_zeromq_ZMQ_00024Context_construct (JNIEnv *env,
 }
 
 /**
+ * Called to initialize a Java Context with a pre-existing zmq context
+ */
+JNIEXPORT void JNICALL Java_org_zeromq_ZMQ_00024Context_initialize (JNIEnv *env,
+                                                                    jobject obj,
+                                                                    jlong ctx_addr)
+{
+    void *c = get_context (env, obj, 0);
+    if (c)
+        return;
+
+    c = (void *) ctx_addr;
+    put_context (env, obj, c);
+
+    if (c == NULL) {
+        raise_exception (env, 1);
+        return;
+    }
+}
+
+
+/**
  * Called to destroy a Java Context object.
  */
 JNIEXPORT void JNICALL Java_org_zeromq_ZMQ_00024Context_finalize (JNIEnv *env,

--- a/src/org/zeromq/ZMQ.java
+++ b/src/org/zeromq/ZMQ.java
@@ -285,6 +285,17 @@ public class ZMQ {
     }
 
     /**
+     * Create a new Context from an existing zmq context, e.g. for sharing contexts between independent libraries
+     *
+     * @param contextAddress
+     *            A pointer to the existing context
+     * @return the Context
+     */
+    public static Context context (long contextAddress) {
+        return new Context (contextAddress);
+    }
+
+    /**
      * Inner class: Context.
      */
     public static class Context {
@@ -337,6 +348,19 @@ public class ZMQ {
         protected Context (int ioThreads) {
             construct (ioThreads);
         }
+
+        /**
+         * Class constructor.
+         *
+         * @param cContextAddr
+         *           the address of a prexisting zmq context
+         */
+        protected Context (long contextAddress) {
+            initialize (contextAddress);
+        }
+
+        /** Initialize the JNI interfaece with pre-existing zmq context **/
+        protected native void initialize (long contextAddress);
 
         /** Initialize the JNI interface */
         protected native void construct (int ioThreads);


### PR DESCRIPTION
We use a shared c library that leans heavily on zmq inproc sockets. This additional constructor allows anyone to pass inproc messages and share a context across languages and/or shared libraries. 
