### PR TITLE
Add bindToRandomPort to Socket class

### DIFF
--- a/src/org/zeromq/ZMQ.java
+++ b/src/org/zeromq/ZMQ.java
@@ -1116,6 +1116,9 @@ public class ZMQ {
                     bind(String.format("%s:%s", addr, port));
                     return port;
                 } catch (ZMQException e) {
+                    if (e.getErrorCode() != ZMQ.EADDRINUSE) {
+                        throw e;
+                    }
                     continue;
                 }
             }


### PR DESCRIPTION
Code come from python binding, https://github.com/zeromq/pyzmq/blob/master/zmq/core/pysocket.py#L114.

Maybe we should handling error more finely.
