### PR TITLE
Update configure.in for automake 1.13.x

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -10,7 +10,7 @@ AC_INIT([jzmq],[2.1.0],[zeromq-dev@lists.zeromq.org])
 
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
-AM_CONFIG_HEADER(src/config.hpp)
+AC_CONFIG_HEADERS(src/config.hpp)
 AM_INIT_AUTOMAKE(tar-ustar)
 
 #


### PR DESCRIPTION
The new automake 1.13.x complains that AM_CONFIG_HEADER is an obsolete macro and refuses to finish during the autogen.sh step. I needed this patch to get jzmq to build jzmq successfully on Mac OS X 10.8.2 with automake 1.13 installed via homebrew.
