### PR TITLE
ZDispatcher does busy waiting comment.

### DIFF
--- a/src/org/zeromq/ZDispatcher.java
+++ b/src/org/zeromq/ZDispatcher.java
@@ -12,10 +12,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Dispatcher for ZeroMQ Sockets.
  *
- * ATTENTION: This code uses busy waiting an may not be production ready!
- * See: https://github.com/zeromq/jzmq/issues/111
+ * Warning:
+ * The Dispatcher uses a busy spin loop when waiting on events.
+ * This is ideal for low latency applications but not in all situations.
+ * It has the side effect of consuming 100% of a CPU when waiting for events.
  *
- * With this dispatcher, you can register ONE handler per socket and get a Sender for sending ZMsg.
+ * With this dispatcher, you can register ONE handler per socket 
+ * and get a Sender for sending ZMsg.
  */
 public class ZDispatcher {
     private ConcurrentMap<ZMQ.Socket, SocketDispatcher> dispatchers = new ConcurrentHashMap<ZMQ.Socket, SocketDispatcher>();


### PR DESCRIPTION
I tried to use the ZDispatcher for a Android project and found out that the dispatcher does busy waiting and consumes 100% CPU. That is not acceptable on a mobile phone and i think should be mentioned somewhere.
