### PR TITLE
Fixed ZMQ.Socket.setRecoveryInterval() to work with v3.0.0 and up.

### DIFF
--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -288,6 +288,7 @@ JNIEXPORT void JNICALL Java_org_zeromq_ZMQ_00024Socket_setLongSockopt (JNIEnv *e
                 || (option == ZMQ_RCVBUF)
                 || (option == ZMQ_SNDHWM)
                 || (option == ZMQ_RCVHWM)
+                || (option == ZMQ_RECOVERY_IVL)
 #endif
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(2,1,0)    
             ) {

--- a/src/org/zeromq/ZMQ.java
+++ b/src/org/zeromq/ZMQ.java
@@ -1024,10 +1024,11 @@ public class ZMQ {
 
         /**
          * The 'ZMQ_RECOVERY_IVL' option shall set the recovery interval for multicast transports using the specified
-         * 'socket'. The recovery interval determines the maximum time in seconds that a receiver can be absent from a
-         * multicast group before unrecoverable data loss will occur.
+         * 'socket'. The recovery interval determines the maximum time in seconds (before version 3.0.0) or milliseconds
+         * (version 3.0.0 and after) that a receiver can be absent from a multicast group before unrecoverable data loss
+         * will occur.
          * 
-         * CAUTION: Excersize care when setting large recovery intervals as the data needed for recovery will be held in
+         * CAUTION: Exercise care when setting large recovery intervals as the data needed for recovery will be held in
          * memory. For example, a 1 minute recovery interval at a data rate of 1Gbps requires a 7GB in-memory buffer.
          * {Purpose of this Method}
          * 


### PR DESCRIPTION
Changed setLongSockopt to use int for ZMQ_RECOVERY_IVL for v3.0.0 and up.  Modified comment for ZMQ.Socket.setRecoveryInterval() to reflect change to milliseconds for v3.0.0 and up.
