### PR TITLE
recvZeroCopy failure is hidden by failure to set position on ByteBuffer

### DIFF
--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -597,7 +597,6 @@ Java_org_zeromq_ZMQ_00024Socket_recvZeroCopy (JNIEnv *env,
     int rc = 0;
     buf = (jbyte*) env->GetDirectBufferAddress(buffer);
     rc = zmq_recv(sock, buf, length, flags);
-    setByteBufferPosition(env, buffer, rc);
     if(rc == -1) {
         int err = zmq_errno();
         if(err == EAGAIN) {
@@ -605,6 +604,7 @@ Java_org_zeromq_ZMQ_00024Socket_recvZeroCopy (JNIEnv *env,
             return 0;
         }
     }
+    setByteBufferPosition(env, buffer, rc);
     return rc;
 #else
     return -1;


### PR DESCRIPTION
when the retrun code from zmq_recv is negative writing the negative value
to the ByteBuffer raises an IllegalArgumentException.
This behavior hides the true error.
