### PR TITLE
Add toString() method to ZMsg to aid debugging

### DIFF
--- a/src/org/zeromq/ZMsg.java
+++ b/src/org/zeromq/ZMsg.java
@@ -335,7 +335,7 @@ public class ZMsg implements Iterable<ZFrame>, Deque<ZFrame> {
     /**
      * Convert the message to a string, for use in debugging.
      */
-    public void toString() {
+    public String toString() {
         StringBuilder sb = new StringBuilder();
         dump(sb);
         return sb.toString();


### PR DESCRIPTION
Handy for when you're using slf4j/log4j, because then you can log messages and have it only build the string lazily, when the log level is high enough to trigger.
