### PR TITLE
Fix compatibility to ZeroMQ 2.x

### DIFF
--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -503,6 +503,7 @@ void s_delete_ref (void *ptr, void *hint)
     delete free_hint;
 }
 
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(3,0,0)
 static
 jboolean s_zerocopy_init (JNIEnv *env, zmq_msg_t *message, jobject obj, jint length)
 {
@@ -522,6 +523,7 @@ jboolean s_zerocopy_init (JNIEnv *env, zmq_msg_t *message, jobject obj, jint len
     }
     return JNI_TRUE;
 }
+#endif
 
 JNIEXPORT jboolean JNICALL
 Java_org_zeromq_ZMQ_00024Socket_sendZeroCopy (JNIEnv *env,
@@ -557,6 +559,7 @@ Java_org_zeromq_ZMQ_00024Socket_sendZeroCopy (JNIEnv *env,
 JNIEXPORT jint JNICALL
 Java_org_zeromq_ZMQ_00024Socket_sendByteBuffer (JNIEnv *env, jobject obj, jobject buffer, jint flags)
 {
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(3,0,0)
     jbyte* buf = 0;
     int rc = 0;
 
@@ -580,6 +583,9 @@ Java_org_zeromq_ZMQ_00024Socket_sendByteBuffer (JNIEnv *env, jobject obj, jobjec
         return -1;
     }
     return rc;
+#else
+    return JNI_FALSE;
+#endif
 }
 
 /**
@@ -690,6 +696,7 @@ Java_org_zeromq_ZMQ_00024Socket_recvZeroCopy (JNIEnv *env,
 JNIEXPORT jint JNICALL
 Java_org_zeromq_ZMQ_00024Socket_recvByteBuffer (JNIEnv *env, jobject obj, jobject buffer, jint flags)
 {
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(3,0,0)
     jbyte* buf = 0;
     int rc = 0;
 
@@ -714,6 +721,9 @@ Java_org_zeromq_ZMQ_00024Socket_recvByteBuffer (JNIEnv *env, jobject obj, jobjec
         }
     }
     return rc;
+#else
+    return JNI_FALSE;
+#endif
 }
 
 /**


### PR DESCRIPTION
This patch fixes this compile problem of building jZMQ for ZeroMQ 2.x:

``` sh
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -D_REENTRANT -D_THREAD_SAFE -I/home/ok/tmp/include -I/usr/lib/jvm/jdk1.7.0_21/include -I/usr/lib/jvm/jdk1.7.0_21/include/linux -Wall -g -O2 -MT libjzmq_la-Socket.lo -MD -MP -MF .deps/libjzmq_la-Socket.Tpo -c Socket.cpp  -fPIC -DPIC -o .libs/libjzmq_la-Socket.o
Socket.cpp: In function 'jint Java_org_zeromq_ZMQ_00024Socket_sendByteBuffer(JNIEnv*, jobject, jobject, jint)':
Socket.cpp:576:44: error: cannot convert 'jbyte* {aka signed char*}' to 'zmq_msg_t*' for argument '2' to 'int zmq_send(void*, zmq_msg_t*, int)'
Socket.cpp: In function 'jint Java_org_zeromq_ZMQ_00024Socket_recvByteBuffer(JNIEnv*, jobject, jobject, jint)':
Socket.cpp:708:43: error: cannot convert 'jbyte* {aka signed char*}' to 'zmq_msg_t*' for argument '2' to 'int zmq_recv(void*, zmq_msg_t*, int)'
Socket.cpp: At global scope:
Socket.cpp:507:10: warning: 'jboolean s_zerocopy_init(JNIEnv*, zmq_msg_t*, jobject, jint)' defined but not used [-Wunused-function]
```
