### PR TITLE
Fixed broken builds for zmq < 4.0.0

### DIFF
--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -347,7 +347,9 @@ JNIEXPORT void JNICALL Java_org_zeromq_ZMQ_00024Socket_setBytesSockopt (JNIEnv *
     case ZMQ_IDENTITY:
     case ZMQ_SUBSCRIBE:
     case ZMQ_UNSUBSCRIBE:
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4,0,0)    
     case ZMQ_ZAP_DOMAIN:
+#endif
         {
             if (value == NULL) {
                 raise_exception (env, EINVAL);


### PR DESCRIPTION
Apologies, it appears my last PR broke the build.  This fixes builds when binding against libzmq < 4.
