### PR TITLE
small fix for debian packaging

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -14,6 +14,7 @@ configure: configure-stamp
 configure-stamp:
 	dh_testdir
 
+	./autogen.sh
 	./configure $(CROSS) \
 	    --prefix=/usr \
 	    CFLAGS="$(CFLAGS)" \


### PR DESCRIPTION
Without the execution of autogen , the configure script isnt created so dpkg-buildpackage will fail 
