### PR TITLE
zauth missing from makefile

### DIFF
--- a/src/main/c++/Makefile.am
+++ b/src/main/c++/Makefile.am
@@ -3,6 +3,7 @@ jardir = $(datadir)/java
 
 JZMQ_JAVA_FILES = \
 	../java/org/zeromq/EmbeddedLibraryTools.java \
+	../java/org/zeromq/ZAuth.java \
 	../java/org/zeromq/ZContext.java \
 	../java/org/zeromq/ZDispatcher.java \
 	../java/org/zeromq/ZFrame.java \


### PR DESCRIPTION
The ZAuth class isn't getting packaged up.  It was removed from the makefile [here](https://github.com/zeromq/jzmq/commit/239ea6e1a2a75448481320701d99e5ed6f034195#diff-480477e89f9b6ddafb30c4383dcdd705L17).  Not sure why...
