### PR TITLE
Added method ZMQ.Socket.setProbeRouter(), issue #333

### DIFF
--- a/src/main/c++/Socket.cpp
+++ b/src/main/c++/Socket.cpp
@@ -326,6 +326,7 @@ JNIEXPORT void JNICALL Java_org_zeromq_ZMQ_00024Socket_setLongSockopt (JNIEnv *e
     case ZMQ_IMMEDIATE:
     case ZMQ_REQ_RELAXED:
     case ZMQ_REQ_CORRELATE:
+    case ZMQ_PROBE_ROUTER:
 #endif
     case ZMQ_AFFINITY:
     case ZMQ_RATE:
@@ -381,6 +382,7 @@ JNIEXPORT void JNICALL Java_org_zeromq_ZMQ_00024Socket_setLongSockopt (JNIEnv *e
                 || (option == ZMQ_IMMEDIATE)
                 || (option == ZMQ_REQ_RELAXED)
                 || (option == ZMQ_REQ_CORRELATE)
+                || (option == ZMQ_PROBE_ROUTER)
 #endif
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4,1,0)
                 || (option == ZMQ_GSSAPI_SERVER)

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -1408,6 +1408,23 @@ public class ZMQ {
                 setLongSockopt(REQ_CORRELATE, isCorrelate ? 1L : 0L);
             }
         }
+        
+        /**
+         * Sets whether the socket should automatically send an empty message 
+         * when a new connection is made or accepted. This may be set on
+         * REQ, DEALER, or ROUTER sockets connected to a ROUTER socket.
+         * The application must filter such empty messages.
+         *
+         * @param isProbeRouter if {@code true}, the socket will automatically 
+         * send an empty message when a new connection is made or
+         * accepted; if {@code false}, no such message will be sent
+         * @since 4.0.0
+         */
+        public void setProbeRouter(boolean isProbeRouter) {
+        	if (ZMQ.version_full() >= ZMQ.make_version(4, 0, 0)) {
+        		setLongSockopt(PROBE_ROUTER, isProbeRouter ? 1L : 0L);
+        	}
+        }       
 
         /**
          * Bind to network interface. Start listening for new connections.
@@ -1791,6 +1808,7 @@ public class ZMQ {
         private static final int PLAIN_SERVER = 44;
         private static final int PLAIN_USERNAME = 45;
         private static final int PLAIN_PASSWORD = 46;
+        private static final int PROBE_ROUTER = 51;
         private static final int REQ_CORRELATE = 52;
         private static final int REQ_RELAXED = 53;
         private static final int CONFLATE = 54;


### PR DESCRIPTION
This seems pretty straightforward, but it's my first attempt at contributing, so please be gentle. I've written a simple test, along the lines of test_probe_router.cpp in the core library tests, and it appears to work properly. Should I incorporate it in the junit tests, and if so, which file would be the appropriate place to put it?

Also, I tried writing a getProbeSocket method, but it ends up that zmq_getsockopt in the core library doesn't support the ZMQ_PROBE_ROUTER option. I don't know whether that constitutes an issue or not. It might be intentional; the documentation for zmq_getsockopt doesn't mention ZMQ_PROBE_ROUTER.
