### PR TITLE
Pass $(JAVACFLAGS) to $(JAVAC) invocations.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -93,6 +93,7 @@ AC_CHECK_LIB([zmq], [zmq_init],
 test "x$JAVAC" = x && AC_CHECK_PROGS(JAVAC, javac -encoding ut8)
 test "x$JAVAC" = x && AC_MSG_ERROR([cannot find javac])
 AC_SUBST(JAVAC)
+AC_SUBST(JAVACFLAGS)
 
 test "x$JAVAH" = x && AC_CHECK_PROGS(JAVAH, javah)
 test "x$JAVAH" = x && AC_MSG_ERROR([cannot find javah])

--- a/src/main/c++/Makefile.am
+++ b/src/main/c++/Makefile.am
@@ -40,7 +40,7 @@ JZMQ_HPP_FILES = \
 JZMQ_CLASS_FILES = org/zeromq/*.class
 
 $(jarfile):
-	$(JAVAC) -d . $(JZMQ_JAVA_FILES)
+	$(JAVAC) $(JAVACFLAGS) -d . $(JZMQ_JAVA_FILES)
 	$(JAR) cf $(JARFLAGS) $@ $(JZMQ_CLASS_FILES)
 
 jar_DATA = $(jarfile)

--- a/src/main/perf/Makefile.am
+++ b/src/main/perf/Makefile.am
@@ -11,7 +11,7 @@ JZMQ_PERF_JAVA_FILES = \
 JZMQ_PERF_CLASS_FILES = *.class
 
 $(jarfile): 
-	$(JAVAC) -classpath $(top_builddir)/src/main/java -d . $(JZMQ_PERF_JAVA_FILES)
+	$(JAVAC) $(JAVACFLAGS) -classpath $(top_builddir)/src/main/java -d . $(JZMQ_PERF_JAVA_FILES)
 	$(JAR) cf $(JARFLAGS) $@ $(JZMQ_PERF_CLASS_FILES)
 
 jar_DATA = $(jarfile)


### PR DESCRIPTION
I'm working on a yocto/openembedded recipe for building jzmq.  In that context, I need to pass -source and -target options to javac, and this change allows that.
