### PR TITLE
Remove code that patched libtool to remove rpath on Linux.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -118,14 +118,3 @@ AC_C_CONST
 AC_TYPE_SIZE_T
 
 AC_OUTPUT(Makefile src/main/c++/Makefile src/main/perf/Makefile)
-
-#  On Linux patch libtool to delete hardcoded paths (rpath).
-case "${host_os}" in
-    *linux*)
-        sed < libtool > libtool-2 \
-        's/^hardcode_libdir_flag_spec.*$'/'hardcode_libdir_flag_spec=" "/'
-        mv libtool-2 libtool
-        chmod 755 libtool
-        ;;
-esac
-


### PR DESCRIPTION
This failed when cross compiling, as the script is called
${host_alias}-libtool instead of libtool; it only supported
Linux systems; and there was no way to disable the behavior.
