### PR TITLE
Use "stamp" files to sequence javac and javah invocations.

### DIFF
--- a/src/main/c++/Makefile.am
+++ b/src/main/c++/Makefile.am
@@ -72,13 +72,13 @@ BUILT_SOURCES = \
 	$(JZMQ_H_FILES)
 
 CLEANFILES = \
-	-rf org \
 	$(JZMQ_H_FILES) \
-	$(JZMQ_CLASS_FILES) \
 	$(jarfile) \
 	$(javac_stamp) \
 	$(javah_stamp)
 
+clean-local:
+	rm -rf org
 
 $(JZMQ_H_FILES): $(javah_stamp)
 $(javah_stamp): $(javac_stamp)


### PR DESCRIPTION
In my build log, I noticed that javah was invoked multiple times, as yocto's bitbake invokes make with the -j flag.

This change introduces the "stamp" file idiom, where a stamp file is used to represent the make targets with multiple files.  While I only truely needed it for javah, I added a stamp file for javac too. This allows the javah invocation to be dispatched at the same time as jar.
