### PR TITLE
improved EmbeddedLibraryTools with zmq shared library loading

### DIFF
--- a/src/main/java/org/zeromq/EmbeddedLibraryTools.java
+++ b/src/main/java/org/zeromq/EmbeddedLibraryTools.java
@@ -140,7 +140,6 @@ public class EmbeddedLibraryTools {
 
     private static boolean tryLoadEmbedded(URL nativeLibraryUrl, String targetName, boolean preload) {
         if (nativeLibraryUrl == null) {
-            System.err.println("could not find " + targetName);
             return false;
         }
 


### PR DESCRIPTION
This works now on Linux and MacOS X and should work on Solaris 11; on the latter two you need to use install_name_tool or elfedit utilities to make the library relocatable, but this is not hard. 

Note it requires minimum Java 7; if concerns about this let me know.
