### PR TITLE
Support for CURVE key generation and encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ INSTALL
 .checkstyle
 javac_stamp
 javah_stamp
+.tags*
+*.sublime-project
+*.sublime-workspace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 before_install:
  - sudo add-apt-repository ppa:trevorbernard/zeromq -y
  - sudo apt-get update -y
- - sudo apt-get install libzmq3-dev libpgm-dev make build-essential pkg-config libtool automake -y
+ - sudo apt-get install libpgm-dev make build-essential pkg-config libtool automake -y
  - git clone git://github.com/jedisct1/libsodium.git
  - cd libsodium
- - git checkout 0.4.5
  - ./autogen.sh
- - ./configure && make check
+ - ./configure && make
+ - sudo make install
+ - sudo ldconfig
+ - cd ..
+ - git clone https://github.com/zeromq/libzmq.git
+ - cd libzmq
+ - ./autogen.sh
+ - ./configure --with-libsodium && make
  - sudo make install
  - sudo ldconfig
  - cd ..

--- a/src/main/c++/Curve.cpp
+++ b/src/main/c++/Curve.cpp
@@ -1,0 +1,109 @@
+/*
+    Copyright (c) 2007-2013 Contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <zmq.h>
+#include <assert.h>
+#include "jzmq.hpp"
+#include "util.hpp"
+#include "org_zeromq_ZMQ_Curve.h"
+
+
+JNIEXPORT jobject JNICALL
+Java_org_zeromq_ZMQ_00024Curve_generateKeyPair(JNIEnv *env, jclass cls)
+{
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4,0,0)
+    char public_key [41];
+    char secret_key [41];
+
+    int rc = zmq_curve_keypair (public_key, secret_key);
+    int err = zmq_errno ();
+
+    if (0 != rc) {
+        raise_exception (env, err);
+        return NULL;
+    }
+
+    jstring pk = env->NewStringUTF (public_key);
+    assert (pk);
+    jstring sk = env->NewStringUTF (secret_key);
+    assert (sk);
+
+    jclass clz = env->FindClass ("org/zeromq/ZMQ$Curve$KeyPair");
+    assert (clz);
+    jmethodID midInit = env->GetMethodID (clz, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
+    assert (midInit);
+    jobject result = env->NewObject (clz, midInit, pk, sk);
+    assert (result);
+
+    return result;
+#else
+    raise_exception (env, ENOTSUP);
+    return NULL;
+#endif
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_org_zeromq_ZMQ_00024Curve_z85Decode(JNIEnv *env, jclass cls, jstring key)
+{
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4,0,0)
+    const char *in_key = env->GetStringUTFChars (key, NULL);
+    assert (in_key);
+
+    uint8_t out_key [32];
+
+    if (NULL == zmq_z85_decode (out_key, in_key)) {
+        env->ReleaseStringUTFChars (key, in_key);
+        return NULL;
+    }
+
+    env->ReleaseStringUTFChars (key, in_key);
+    jbyteArray result = env->NewByteArray (32);
+    env->SetByteArrayRegion (result, 0 , 32, reinterpret_cast<jbyte*>(out_key));
+
+    return result;
+#else
+    raise_exception (env, ENOTSUP);
+    return NULL;
+#endif
+}
+
+JNIEXPORT jstring JNICALL
+Java_org_zeromq_ZMQ_00024Curve_z85Encode(JNIEnv *env, jclass cls, jbyteArray key)
+{
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4,0,0)
+    jbyte *in_key = env->GetByteArrayElements (key, NULL);
+    assert (in_key);
+
+    char string_key [41];
+
+    if (NULL == zmq_z85_encode (string_key, reinterpret_cast<uint8_t*>(in_key), 32)) {
+        env->ReleaseByteArrayElements (key, in_key, 0);
+        return NULL;
+    }
+
+    env->ReleaseByteArrayElements (key, in_key, 0);
+    jstring result = env->NewStringUTF (string_key);
+    assert (result);
+
+    return result;
+#else
+    raise_exception (env, ENOTSUP);
+    return NULL;
+#endif
+}

--- a/src/main/c++/Makefile.am
+++ b/src/main/c++/Makefile.am
@@ -26,7 +26,8 @@ JZMQ_CPP_FILES = \
 	Socket.cpp \
 	Poller.cpp \
 	Event.cpp \
-	util.cpp
+	util.cpp \
+	Curve.cpp
 
 JZMQ_H_FILES = \
 	org_zeromq_ZMQ.h \
@@ -35,7 +36,9 @@ JZMQ_H_FILES = \
 	org_zeromq_ZMQ_Event.h \
 	org_zeromq_ZMQ_PollItem.h \
 	org_zeromq_ZMQ_Poller.h \
-	org_zeromq_ZMQ_Socket.h
+	org_zeromq_ZMQ_Socket.h \
+	org_zeromq_ZMQ_Curve.h \
+	org_zeromq_ZMQ_Curve_KeyPair.h
 
 JZMQ_HPP_FILES = \
 	util.hpp

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -2383,4 +2383,52 @@ public class ZMQ {
             return Event.recv(socket, 0);
         }
     }
+
+    /**
+     * Class that interfaces the generation of CURVE key pairs
+     */
+    public static class Curve {
+        /**
+         * A container for a public and a corresponding secret key
+         */
+        public static class KeyPair {
+            public final String publicKey;
+            public final String secretKey;
+
+            public KeyPair(final String publicKey, final String secretKey) {
+                this.publicKey = publicKey;
+                this.secretKey = secretKey;
+            }
+        }
+
+        /**
+         * Returns a newly generated random keypair consisting of a public key
+         * and a secret key.
+         *
+         * <p>The keys are encoded using {@link #z85Encode}.</p>
+         *
+         * @return Randomly generated {@link KeyPair}
+         */
+        public native static KeyPair generateKeyPair();
+
+        /**
+         * The function shall decode given key encoded as Z85 string into byte array.
+         *
+         * <p>The decoding shall follow the ZMQ RFC 32 specification.</p>
+         *
+         * @param key Key to be decoded
+         * @return The resulting key as byte array
+         */
+        public native static byte[] z85Decode(String key);
+
+        /**
+         * The function shall encode the binary block specified into a string.
+         *
+         * <p>The encoding shall follow the ZMQ RFC 32 specification.</p>
+         *
+         * @param key Key to be encoded
+         * @return The resulting key as String in Z85
+         */
+        public native static String z85Encode(byte[] key);
+    }
 }


### PR DESCRIPTION
Adds support for CURVE key generation and encoding. 

This is another take at a [PR that I closed due to Travis build fail.](https://github.com/zeromq/jzmq/pull/390) The build fail required I update the `.travis.yml` file. I set it to use the latest libsodium and libzmq libraries. Since Travis now has to compile and install a new dependency, new builds take a bit (30-60 seconds) longer to complete. I hope that is ok.
