### PR TITLE
Fix regression in EmbeddedLibraryTool on Windows

### DIFF
--- a/src/main/java/org/zeromq/EmbeddedLibraryTools.java
+++ b/src/main/java/org/zeromq/EmbeddedLibraryTools.java
@@ -146,9 +146,7 @@ public class EmbeddedLibraryTools {
 
                 System.load(libfile.getAbsolutePath());
 
-                if (!libfile.delete()) {
-                    throw new IllegalStateException("unable to delete " + libfile);
-                }
+                libfile.delete();
 
                 usingEmbedded = true;
 


### PR DESCRIPTION
Commit https://github.com/zeromq/jzmq/commit/64fafd3800a914d2ef5b35943c5c303328157f34 introduced a regression in EmbeddedLibraryTool on Windows.

On Windows the temporary library file cannot be deleted while it is loaded, thus loadEmbeddedLibrary() always throws an IllegalStateException, when a matching DLL is found in the classpath. This will even result in an ExceptionInInitializerError in the static constructor of EmbeddedLibraryTool.