### PR TITLE
Fix cannot find symbol: Utils.checkNotNull issue for msvc build

### DIFF
--- a/builds/msvc/jzmq/jzmq.vcxproj
+++ b/builds/msvc/jzmq/jzmq.vcxproj
@@ -83,7 +83,7 @@
     <PreBuildEvent>
       <Message>Compiling Java classes</Message>
       <Command>
-javac ..\..\..\src\main\java\org\zeromq\ZMQ.java ..\..\..\src\main\java\org\zeromq\ZMQException.java ..\..\..\src\main\java\org\zeromq\ZMQForwarder.java ..\..\..\src\main\java\org\zeromq\ZMQQueue.java ..\..\..\src\main\java\org\zeromq\ZMQStreamer.java ..\..\..\src\main\java\org\zeromq\EmbeddedLibraryTools.java ..\..\..\src\main\java\org\zeromq\App.java ..\..\..\src\main\java\org\zeromq\ZContext.java ..\..\..\src\main\java\org\zeromq\ZDispatcher.java ..\..\..\src\main\java\org\zeromq\ZFrame.java ..\..\..\src\main\java\org\zeromq\ZMsg.java
+javac ..\..\..\src\main\java\org\zeromq\ZMQ.java ..\..\..\src\main\java\org\zeromq\ZMQException.java ..\..\..\src\main\java\org\zeromq\ZMQForwarder.java ..\..\..\src\main\java\org\zeromq\ZMQQueue.java ..\..\..\src\main\java\org\zeromq\Utils.java ..\..\..\src\main\java\org\zeromq\ZMQStreamer.java ..\..\..\src\main\java\org\zeromq\EmbeddedLibraryTools.java ..\..\..\src\main\java\org\zeromq\App.java ..\..\..\src\main\java\org\zeromq\ZContext.java ..\..\..\src\main\java\org\zeromq\ZDispatcher.java ..\..\..\src\main\java\org\zeromq\ZFrame.java ..\..\..\src\main\java\org\zeromq\ZMsg.java
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -111,7 +111,7 @@ jar -cvf ..\..\..\lib\zmq.jar org\zeromq\*.class
     <PreBuildEvent>
       <Message>Compiling Java classes</Message>
       <Command>
-javac ..\..\..\src\main\java\org\zeromq\ZMQ.java ..\..\..\src\main\java\org\zeromq\ZMQException.java ..\..\..\src\main\java\org\zeromq\ZMQForwarder.java ..\..\..\src\main\java\org\zeromq\ZMQQueue.java ..\..\..\src\main\java\org\zeromq\ZMQStreamer.java ..\..\..\src\main\java\org\zeromq\EmbeddedLibraryTools.java ..\..\..\src\main\java\org\zeromq\App.java ..\..\..\src\main\java\org\zeromq\ZContext.java ..\..\..\src\main\java\org\zeromq\ZDispatcher.java ..\..\..\src\main\java\org\zeromq\ZFrame.java ..\..\..\src\main\java\org\zeromq\ZMsg.java
+javac ..\..\..\src\main\java\org\zeromq\ZMQ.java ..\..\..\src\main\java\org\zeromq\ZMQException.java ..\..\..\src\main\java\org\zeromq\ZMQForwarder.java ..\..\..\src\main\java\org\zeromq\ZMQQueue.java ..\..\..\src\main\java\org\zeromq\Utils.java ..\..\..\src\main\java\org\zeromq\ZMQStreamer.java ..\..\..\src\main\java\org\zeromq\EmbeddedLibraryTools.java ..\..\..\src\main\java\org\zeromq\App.java ..\..\..\src\main\java\org\zeromq\ZContext.java ..\..\..\src\main\java\org\zeromq\ZDispatcher.java ..\..\..\src\main\java\org\zeromq\ZFrame.java ..\..\..\src\main\java\org\zeromq\ZMsg.java
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -138,7 +138,7 @@ jar -cvf ..\..\..\lib\zmq.jar org\zeromq\*.class
       <Message>Compiling Java classes</Message>
       <Command>
           copy ..\config.hpp ..\..\..\src\main\c++\
-          javac ..\..\..\src\main\java\org\zeromq\ZMQ.java ..\..\..\src\main\java\org\zeromq\ZMQException.java ..\..\..\src\main\java\org\zeromq\ZMQForwarder.java ..\..\..\src\main\java\org\zeromq\ZMQQueue.java ..\..\..\src\main\java\org\zeromq\ZMQStreamer.java ..\..\..\src\main\java\org\zeromq\EmbeddedLibraryTools.java ..\..\..\src\main\java\org\zeromq\App.java ..\..\..\src\main\java\org\zeromq\ZContext.java ..\..\..\src\main\java\org\zeromq\ZDispatcher.java ..\..\..\src\main\java\org\zeromq\ZFrame.java ..\..\..\src\main\java\org\zeromq\ZMsg.java
+          javac ..\..\..\src\main\java\org\zeromq\ZMQ.java ..\..\..\src\main\java\org\zeromq\ZMQException.java ..\..\..\src\main\java\org\zeromq\ZMQForwarder.java ..\..\..\src\main\java\org\zeromq\ZMQQueue.java ..\..\..\src\main\java\org\zeromq\Utils.java ..\..\..\src\main\java\org\zeromq\ZMQStreamer.java ..\..\..\src\main\java\org\zeromq\EmbeddedLibraryTools.java ..\..\..\src\main\java\org\zeromq\App.java ..\..\..\src\main\java\org\zeromq\ZContext.java ..\..\..\src\main\java\org\zeromq\ZDispatcher.java ..\..\..\src\main\java\org\zeromq\ZFrame.java ..\..\..\src\main\java\org\zeromq\ZMsg.java
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -169,7 +169,7 @@ jar -cvf ..\..\..\lib\zmq.jar org\zeromq\*.class
       <Message>Compiling Java classes</Message>
       <Command>
           copy ..\config.hpp ..\..\..\src\main\c++\
-          javac ..\..\..\src\main\java\org\zeromq\ZMQ.java ..\..\..\src\main\java\org\zeromq\ZMQException.java ..\..\..\src\main\java\org\zeromq\ZMQForwarder.java ..\..\..\src\main\java\org\zeromq\ZMQQueue.java ..\..\..\src\main\java\org\zeromq\ZMQStreamer.java ..\..\..\src\main\java\org\zeromq\EmbeddedLibraryTools.java ..\..\..\src\main\java\org\zeromq\App.java ..\..\..\src\main\java\org\zeromq\ZContext.java ..\..\..\src\main\java\org\zeromq\ZDispatcher.java ..\..\..\src\main\java\org\zeromq\ZFrame.java ..\..\..\src\main\java\org\zeromq\ZMsg.java
+          javac ..\..\..\src\main\java\org\zeromq\ZMQ.java ..\..\..\src\main\java\org\zeromq\ZMQException.java ..\..\..\src\main\java\org\zeromq\ZMQForwarder.java ..\..\..\src\main\java\org\zeromq\ZMQQueue.java ..\..\..\src\main\java\org\zeromq\Utils.java ..\..\..\src\main\java\org\zeromq\ZMQStreamer.java ..\..\..\src\main\java\org\zeromq\EmbeddedLibraryTools.java ..\..\..\src\main\java\org\zeromq\App.java ..\..\..\src\main\java\org\zeromq\ZContext.java ..\..\..\src\main\java\org\zeromq\ZDispatcher.java ..\..\..\src\main\java\org\zeromq\ZFrame.java ..\..\..\src\main\java\org\zeromq\ZMsg.java
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -289,6 +289,28 @@ jar -cvf ..\..\..\lib\zmq.jar org\zeromq\*.class
       </Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">org_zeromq_ZMQQueue.h;%(Outputs)</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">org_zeromq_ZMQQueue.h;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\..\src\main\java\org\zeromq\Utils.java">
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Generating JNI header</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Generating JNI header</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+          javah -jni -classpath ..\..\..\src\main\java -d ..\..\..\src\main\c++ org.zeromq.Utils
+      </Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+          javah -jni -classpath ..\..\..\src\main\java -d ..\..\..\src\main\c++ org.zeromq.Utils
+      </Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">org_zeromq_Utils.h;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">org_zeromq_Utils.h;%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Generating JNI header</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Generating JNI header</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+          javah -jni -classpath ..\..\..\src\main\java -d ..\..\..\src\main\c++ org.zeromq.Utils
+      </Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+          javah -jni -classpath ..\..\..\src\main\java -d ..\..\..\src\main\c++ org.zeromq.Utils
+      </Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">org_zeromq_Utils.h;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">org_zeromq_Utils.h;%(Outputs)</Outputs>
     </CustomBuild>
     <CustomBuild Include="..\..\..\src\main\java\org\zeromq\ZMQStreamer.java">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Generating JNI header</Message>


### PR DESCRIPTION
msvc build failed with the following error:
1>  ..\..\..\src\main\java\org\zeromq\ZFrame.java:34: error: cannot find symbol
1>          Utils.checkNotNull(data);
1>          ^
1>    symbol:   variable Utils
1>    location: class ZFrame