### PR TITLE
Added LAST_ENDPOINT support.

### DIFF
--- a/src/main/c++/Socket.cpp
+++ b/src/main/c++/Socket.cpp
@@ -243,6 +243,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_zeromq_ZMQ_00024Socket_getBytesSockopt (JN
 {
     switch (option) {
     case ZMQ_IDENTITY:
+    case ZMQ_LAST_ENDPOINT:
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4,0,0)
     case ZMQ_PLAIN_USERNAME:
     case ZMQ_PLAIN_PASSWORD:

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -738,6 +738,17 @@ public class ZMQ {
         }
 
         /**
+         * Returns the endpoint address represented by the last bind operation. This is useful for
+         * determining the port that was assigned by the operating system in instances where the bind
+         * address contains wildcards, such as tcp://*:*.
+         *
+         * @return the last endpoint.
+         */
+        public byte[] getLastEndpoint() {
+            return getBytesSockopt(LAST_ENDPOINT);
+        }
+
+        /**
          * @see #setRate(long)
          * 
          * @return the Rate.
@@ -1865,6 +1876,7 @@ public class ZMQ {
         private static final int RCVTIMEO = 27;
         private static final int SNDTIMEO = 28;
         private static final int IPV4ONLY = 31;
+        private static final int LAST_ENDPOINT = 32;
         private static final int ROUTER_MANDATORY = 33;
         private static final int KEEPALIVE = 34;
         private static final int KEEPALIVECNT = 35;


### PR DESCRIPTION
Added ZMQ constant LAST_ENDPOINT and method getLastEndpoint() and that returns the address of the last bind operation. This is useful for determining the port that was assigned by the operating system in instances where the bind address contains wildcards, such as tcp://*:*.