### PR TITLE
Added version checks for ZMQ_LAST_ENDPOINT and getLastEndpoint() call.

### DIFF
--- a/src/main/c++/Socket.cpp
+++ b/src/main/c++/Socket.cpp
@@ -243,7 +243,9 @@ JNIEXPORT jbyteArray JNICALL Java_org_zeromq_ZMQ_00024Socket_getBytesSockopt (JN
 {
     switch (option) {
     case ZMQ_IDENTITY:
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(3,2,0)
     case ZMQ_LAST_ENDPOINT:
+#endif
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4,0,0)
     case ZMQ_PLAIN_USERNAME:
     case ZMQ_PLAIN_PASSWORD:

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -745,7 +745,11 @@ public class ZMQ {
          * @return the last endpoint.
          */
         public byte[] getLastEndpoint() {
-            return getBytesSockopt(LAST_ENDPOINT);
+            if (ZMQ.version_full() >= ZMQ.make_version(3, 2, 0)) {
+                return getBytesSockopt(LAST_ENDPOINT);
+            } else {
+                return null;
+            }
         }
 
         /**


### PR DESCRIPTION
Added #ifdef version check to prevent compilation errors with < ZMQ 3.2.0 and ZMQ_LAST_ENDPOINT. Added Java runtime version check as well.