### PR TITLE
Problem: mvn package is broken

### DIFF
--- a/jzmq-core/pom.xml
+++ b/jzmq-core/pom.xml
@@ -19,4 +19,13 @@
       <version>3.1.1-SNAPSHOT</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.commonjava.maven.plugins</groupId>
+        <artifactId>directory-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/jzmq-devices/pom.xml
+++ b/jzmq-devices/pom.xml
@@ -19,4 +19,13 @@
       <version>3.1.1-SNAPSHOT</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.commonjava.maven.plugins</groupId>
+        <artifactId>directory-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/jzmq-jni/pom.xml
+++ b/jzmq-jni/pom.xml
@@ -52,6 +52,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.commonjava.maven.plugins</groupId>
+        <artifactId>directory-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
       </activation>
       <properties>
         <native.os>${os.name}</native.os>
-        <native.path>${session.executionRootDirectory}/jzmq-jni/src/main/c++/.libs/libjzmq.so</native.path>
-        <native.library-path>${session.executionRootDirectory}/jzmq-jni/src/main/c++/.libs/</native.library-path>
+        <native.path>${root.directory}/jzmq-jni/src/main/c++/.libs/libjzmq.so</native.path>
+        <native.library-path>${root.directory}/jzmq-jni/src/main/c++/.libs/</native.library-path>
       </properties>
     </profile>
     <profile>
@@ -77,8 +77,8 @@
       </activation>
       <properties>
         <native.os>Windows</native.os>
-        <native.path>${session.executionRootDirectory}/jzmq-jni/lib/jzmq.dll</native.path>
-        <native.library-path>${session.executionRootDirectory}/jzmq-jni/lib</native.library-path>
+        <native.path>${root.directory}/jzmq-jni/lib/jzmq.dll</native.path>
+        <native.library-path>${root.directory}/jzmq-jni/lib</native.library-path>
       </properties>
     </profile>
     <profile>
@@ -90,8 +90,8 @@
       </activation>
       <properties>
         <native.os>${os.name}</native.os>
-        <native.path>${session.executionRootDirectory}/jzmq-jni/src/main/c++/.libs/libjzmq.dylib</native.path>
-        <native.library-path>${session.executionRootDirectory}/jzmq-jni/src/main/c++/.libs/</native.library-path>
+        <native.path>${root.directory}/jzmq-jni/src/main/c++/.libs/libjzmq.dylib</native.path>
+        <native.library-path>${root.directory}/jzmq-jni/src/main/c++/.libs/</native.library-path>
       </properties>
     </profile>
     <profile>
@@ -119,6 +119,23 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.commonjava.maven.plugins</groupId>
+          <artifactId>directory-maven-plugin</artifactId>
+          <version>0.1</version>
+          <executions>
+            <execution>
+              <id>directories</id>
+              <goals>
+                <goal>highest-basedir</goal>
+              </goals>
+              <phase>initialize</phase>
+              <configuration>
+                <property>root.directory</property>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
Solution: Replace the usage of ${session.rootDirectory} with
directory-maven-plugin.

The plugin seems to get the correct path in all cases and mvn package
runs cleanly on my box. I can't test mvn install because it requires
some GPG key which I don't have.

This should fix #412 