### PR TITLE
Problem: build instructions do not consider new module structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,13 @@ Building and Installing JZMQ
 To build you need to have the libzmq library already installed, then you run:
 
 ```bash
+cd jzmq-jni/
 ./autogen.sh
 ./configure
 make
 make install
+cd ..
+mvn package
 ```
 
 Avoiding JNI


### PR DESCRIPTION
Solution: Add instructions to change directory to jzmq-jni before
compiling JNI stuff.

This fixes #413 