### PR TITLE
Problem: Project does not define contribution process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to JZMQ
+
+The contributors are listed in AUTHORS (add yourself). This project uses the LGPL v3 license, see COPYING.
+
+JZMQ uses the [C4.1 (Collective Code Construction Contract)](http://rfc.zeromq.org/spec:22) process for contributions. Please read this if you are unfamiliar with it.
+
+JZMQ grows by the slow and careful accretion of simple, minimal solutions to real problems faced by many people. Some people seem to not understand this. So in case of doubt:
+
+* Each patch defines one clear and agreed problem, and one clear, minimal, plausible solution. If you come with a large, complex problem and a large, complex solution, you will provoke a negative reaction from JZMQ maintainers and users.
+
+* We will usually merge patches aggressively, without a blocking review. If you send us bad patches, without taking the care to read and understand our rules, that reflects on you. Do NOT expect us to do your homework for you.
+
+* As rapidly we will merge poor quality patches, we will remove them again. If you insist on arguing about this and trying to justify your changes, we will simply ignore you and your patches. If you still insist, we will ban you.
+
+* JZMQ is not a sandbox where "anything goes until the next stable release". If you want to experiment, please work in your own projects.


### PR DESCRIPTION
Solution: Steal CONTRIBUTING.md from czmq project.

This fixes #418 