### PR TITLE
Added ZMQ.STREAM for native tcp bidirectional communication

### DIFF
--- a/jzmq-jni/src/main/java/org/zeromq/ZMQ.java
+++ b/jzmq-jni/src/main/java/org/zeromq/ZMQ.java
@@ -113,6 +113,10 @@ public class ZMQ {
      * Flag to specify the receiving part of the PUB or XPUB socket. Allows
      */
     public static final int XSUB = 10;
+    /**
+     * Flag to specify the receiving part of the PUB or XPUB socket. Allows
+     */
+    public static final int STREAM = 11;
 
     /**
      * Flag to specify a STREAMER device.


### PR DESCRIPTION
This is to add another flag in ZMQ class, for STREAM socket creation, for native tcp bidirectional communication.