### PR TITLE
Fixing ZAuthTest

### DIFF
--- a/jzmq-core/src/main/java/org/zeromq/ZAuth.java
+++ b/jzmq-core/src/main/java/org/zeromq/ZAuth.java
@@ -165,6 +165,11 @@ public class ZAuth {
                 // If the file doesn't exist we'll get an empty map
                 String filename = msg.popString();
                 this.passwords_file = new File(filename);
+
+                if (verbose) {
+            		System.out.println("ZAuth: - activated plain-mechanism with password-file:"+this.passwords_file.getAbsolutePath());
+            	}
+
                 this.loadPasswords(true);
 
                 ZMsg reply = new ZMsg();

--- a/jzmq-core/src/test/java/org/zeromq/ZAuthTest.java
+++ b/jzmq-core/src/test/java/org/zeromq/ZAuthTest.java
@@ -48,9 +48,9 @@ public class ZAuthTest {
 		    //  Whitelist our address; any other address will be rejected
 		    auth.allow("127.0.0.1");
 		    auth.configurePlain("*", "passwords");
-		    // Make sure the ZAP-Request to configure plain got through before the sockets start working...
-		    // This usually works without sleeping, but there is a chance the ZAP-Request is not handled before
-		    // the sockets read/write and then it will throw a nullpointer cause the configuration didn't run already
+		    // Make sure the ZAuthAgent's command to configure plain-mechanism got through before the sockets start working...
+		    // This usually works without sleeping, but there is a chance the command is not handled before
+		    // the sockets read/write and then it will throw an error cause the configuration didn't run already
 		    // TODO: Look deeper into that issue 
 		    TestUtils.sleep(100);
 		    
@@ -99,6 +99,11 @@ public class ZAuthTest {
 		    //  Whitelist our address; any other address will be rejected
 		    auth.allow("127.0.0.1");
 		    auth.configureCurve(ZAuth.CURVE_ALLOW_ANY);
+		    // Make sure the ZAuthAgent's command to configure plain-mechanism got through before the sockets start working...
+		    // This usually works without sleeping, but there is a chance the command is not handled before
+		    // the sockets read/write and then it will throw an error cause the configuration didn't run already
+		    // TODO: Look deeper into that issue 
+		    TestUtils.sleep(100);
 
 		    //  We need two certificates, one for the client and one for
 		    //  the server. The client must know the server's public key
@@ -151,6 +156,12 @@ public class ZAuthTest {
 		    auth.allow("127.0.0.1");
 		    //  Tell authenticator to use the certificate store in .curve
 		    auth.configureCurve(CERTIFICATE_FOLDER);
+		    // Make sure the ZAuthAgent's command to configure plain-mechanism got through before the sockets start working...
+		    // This usually works without sleeping, but there is a chance the command is not handled before
+		    // the sockets read/write and then it will throw an error cause the configuration didn't run already
+		    // TODO: Look deeper into that issue 
+		    TestUtils.sleep(100);
+		    
 
 		    //  We'll generate a new client certificate and save the public part
 		    //  in the certificate store (in practice this would be done by hand
@@ -214,6 +225,11 @@ public class ZAuthTest {
 		    auth.allow("127.0.0.1");
 		    //  Tell authenticator to use the certificate store in .curve
 		    auth.configureCurve(CERTIFICATE_FOLDER);
+		    // Make sure the ZAuthAgent's command to configure plain-mechanism got through before the sockets start working...
+		    // This usually works without sleeping, but there is a chance the command is not handled before
+		    // the sockets read/write and then it will throw an error cause the configuration didn't run already
+		    // TODO: Look deeper into that issue 
+		    TestUtils.sleep(100);
 
 		    //  We'll generate a new client certificate and save the public part
 		    //  in the certificate store (in practice this would be done by hand

--- a/jzmq-core/src/test/java/org/zeromq/ZAuthTest.java
+++ b/jzmq-core/src/test/java/org/zeromq/ZAuthTest.java
@@ -123,7 +123,7 @@ public class ZAuthTest {
 		    //  Send a single message from server to client
 		    server.send("Hello");
 		    String message = client.recvStr(0,Charset.defaultCharset());
-		    
+		    assert(message != null);
 		    assert(message.equals("Hello"));
 		}
 		finally {
@@ -181,6 +181,7 @@ public class ZAuthTest {
 		    assert(sendSuccessful);
 		    
 		    String message = client.recvStr(0,Charset.defaultCharset());
+		    assert(message != null);
 		    assert(message.equals("Hello"));
 		}
 		finally {


### PR DESCRIPTION
Ok, I hope this is the last pullrequest concerning this. I stumbled over a problem see here: https://github.com/zeromq/jzmq/issues/447

I added some sleep-time after the configure-calls to ensure that configureCurve and configurePlain are actually processed when the sockets start their work. That seems to work now more or less stable, still very hacky...