### PR TITLE
EmbeddedLibraryTools: Add Windows specific library names. 

### DIFF
--- a/jzmq-jni/src/main/java/org/zeromq/EmbeddedLibraryTools.java
+++ b/jzmq-jni/src/main/java/org/zeromq/EmbeddedLibraryTools.java
@@ -114,7 +114,7 @@ public class EmbeddedLibraryTools {
         String[] libs;
         final String libsFromProps = System.getProperty("jzmq.libs");
         if (libsFromProps == null)
-            libs = new String[]{"libsodium", "libzmq", "libjzmq"};
+            libs = new String[]{"libsodium", "sodium", "libzmq", "zmq", "libjzmq", "jzmq"};
         else
             libs = libsFromProps.split(",");
         StringBuilder url = new StringBuilder();


### PR DESCRIPTION
Windows does not use a prefix for .dll files. 
So libjzmq should be jzmq and so on for the other referenced libraries.

Very trivial change that should not cause any errors on Linux or Windows tests.

- tested on Windows 10 Pro
- tested on SLES 12 SP2