### PR TITLE
fixed build with java 10

### DIFF
--- a/jzmq-jni/configure.in
+++ b/jzmq-jni/configure.in
@@ -95,10 +95,6 @@ test "x$JAVAC" = x && AC_MSG_ERROR([cannot find javac])
 AC_SUBST(JAVAC)
 AC_SUBST(JAVACFLAGS)
 
-test "x$JAVAH" = x && AC_CHECK_PROGS(JAVAH, javah)
-test "x$JAVAH" = x && AC_MSG_ERROR([cannot find javah])
-AC_SUBST(JAVAH)
-
 test "x$JAR" = x && AC_CHECK_PROGS(JAR, jar)
 test "x$JAR" = x && AC_MSG_ERROR([cannot find jar])
 AC_SUBST(JAR)

--- a/jzmq-jni/src/main/c++/Makefile.am
+++ b/jzmq-jni/src/main/c++/Makefile.am
@@ -2,7 +2,6 @@ jarfile = zmq.jar
 jardir = $(datadir)/java
 
 javac_stamp = javac_stamp
-javah_stamp = javah_stamp
 
 JZMQ_JAVA_FILES = \
 	../java/org/zeromq/EmbeddedLibraryTools.java \
@@ -35,7 +34,7 @@ JZMQ_HPP_FILES = \
 JZMQ_CLASS_FILES = org/zeromq/*.class
 
 $(javac_stamp): $(JZMQ_JAVA_FILES)
-	$(JAVAC) $(JAVACFLAGS) -d . $(JZMQ_JAVA_FILES)
+	$(JAVAC) $(JAVACFLAGS) -d . -h . $(JZMQ_JAVA_FILES)
 	@touch $@
 
 $(jarfile): $(javac_stamp)
@@ -66,16 +65,12 @@ BUILT_SOURCES = \
 CLEANFILES = \
 	$(JZMQ_H_FILES) \
 	$(jarfile) \
-	$(javac_stamp) \
-	$(javah_stamp)
+	$(javac_stamp)
 
 clean-local:
 	rm -rf org
 
-$(JZMQ_H_FILES): $(javah_stamp)
-$(javah_stamp): $(javac_stamp)
-	$(CLASSPATH_ENV) $(JAVAH) -jni -classpath . org.zeromq.ZMQ
-	@touch $@
+$(JZMQ_H_FILES): $(javac_stamp)
 
 $(srcdir)/ZMQ.cpp: \
 	$(JZMQ_H_FILES) \


### PR DESCRIPTION
Uses javac -h instead of javah. Needs at least java 8.

(see http://www.oracle.com/technetwork/java/javase/10-relnote-issues-4108729.html#JDK-8182758 )