### PR TITLE
FIX UnsatisfiedLinkError

### DIFF
--- a/jzmq-jni/src/main/java/org/zeromq/EmbeddedLibraryTools.java
+++ b/jzmq-jni/src/main/java/org/zeromq/EmbeddedLibraryTools.java
@@ -25,7 +25,7 @@ public class EmbeddedLibraryTools {
         if (osName.toLowerCase().contains("windows")) {
             osName = "Windows";
         } else if (osName.toLowerCase().contains("mac os x")) {
-            osName = "Darwin";
+            osName = "Mac OS X";
         } else {
             osName = osName.replaceAll("\\s+", "_");
         }


### PR DESCRIPTION
os.name = Mac OS X
libpath =  NATIVE/x86_64/Mac OS X/libjzmq.dylib
loadlibrary( NATIVE/x86_64/Darwin/libjzmq.dylib) crashes