### PR TITLE
Fix error on make: illegal character: '\u00a0'

### DIFF
--- a/jzmq-jni/src/main/java/org/zeromq/ZMQ.java
+++ b/jzmq-jni/src/main/java/org/zeromq/ZMQ.java
@@ -664,7 +664,7 @@ public class ZMQ {
             return getLongSockopt(HWM);
         }
       
-        /**
+        /**
         * @see #setRouterHandover(long)
         *
         * @return the number of messages for handover.
@@ -1079,7 +1079,7 @@ public class ZMQ {
             setLongSockopt(HWM, hwm);
         }
       
-        /**
+        /**
         * For use ROUTER_HANDOVER
         * @param handover the number of handover
         */
@@ -1088,7 +1088,7 @@ public class ZMQ {
                 return;
             else
             {
-                setLongSockopt(56, handover);
+                setLongSockopt(56, handover);
                 return;
             }
         }


### PR DESCRIPTION
Fixes issue #475.

Replaced all occurrences of the illegal character with common spaces.