### PR TITLE
Update ZMsg.save() and ZMsg.dump()

### DIFF
--- a/jzmq-core/src/main/java/org/zeromq/ZMsg.java
+++ b/jzmq-core/src/main/java/org/zeromq/ZMsg.java
@@ -239,7 +239,7 @@ public class ZMsg implements Deque<ZFrame>
                     // Write byte size of frame
                     file.writeInt(f.size());
                     // Write frame byte data
-                    file.write(f.getData());
+                    file.write(f.hasData() ? f.getData() : new byte[0]);
                 }
             }
             return true;
@@ -342,7 +342,7 @@ public class ZMsg implements Deque<ZFrame>
             PrintWriter pw = new PrintWriter(sw);
             pw.printf("--------------------------------------\n");
             for (ZFrame frame : frames) {
-                pw.printf("[%03d] %s\n", frame.getData().length, frame.toString());
+                pw.printf("[%03d] %s\n", frame.hasData() ? frame.getData().length : 0, frame.toString());
             }
             out.append(sw.getBuffer());
             sw.close();


### PR DESCRIPTION
These functions no longer throw NullPointerExceptions due to ZMsg objects having ZFrames created with default ZFrame() public constructor