### PR TITLE
Adapted cmake jni to vckpg and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,95 +28,39 @@ If you hope to install to your local maven, then you should run:
 mvn install -Dgpg.skip=true
 ```
 
-Building Windows 64bit with CMake & NMake
+Building Windows 64bit with CMake & vcpkg
 -----------------------------------------
 
-It is recommended to follow these steps with the *Visual C++ 2015 Build Tools*.
+It is recommended to follow these steps with *vcpkg* and a *Visual C++* compiler.
 
-1. create a new and empty directory:
-```
-d:\temp\>mkdir JZMQ
-d:\temp\>cd JZMQ
-d:\temp\JZMQ\>
-```
-2. Clone the repository to your new directory
-```
-d:\temp\JZMQ\>git clone https://github.com/zeromq/jzmq.git
-```
-3. dive into the checkedout repository and create a new build64 folder
-```
-d:\temp\JZMQ\>cd jzmq\jzmq-jni
-d:\temp\JZMQ\jzmq\jzmq-jni\>mkdir build64
-d:\temp\JZMQ\jzmq\jzmq-jni\>cd build64
-```
-4. Now call CMake to generate the project
-```
-D:\temp\JZMQ\jzmq\jzmq-jni\build64>cmake .. -G "NMake Makefiles" -DZMQ_C_INCLUDE_PATH=<path to zmq include> -DZMQ_C_LIB_PATH=<path to zmq library>
--- The C compiler identification is MSVC 19.0.24210.0
--- The CXX compiler identification is MSVC 19.0.24210.0
--- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/cl.exe
--- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/cl.exe -- works
--- Detecting C compiler ABI info
--- Detecting C compiler ABI info - done
--- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/cl.exe
--- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/cl.exe -- works
--- Detecting CXX compiler ABI info
--- Detecting CXX compiler ABI info - done
--- Detecting CXX compile features
--- Detecting CXX compile features - done
--- Found Java: C:/Program Files/Java/jdk1.8.0_91/bin/java.exe (found version "1.8.0.91")
--- Found JNI: C:/Program Files/Java/jdk1.8.0_91/lib/jawt.lib
--- Configuring done
--- Generating done
--- Build files have been written to: D:/temp/JZMQ/jzmq/jzmq-jni/build64
-```
-5. Now finally call NMake to build the zmq.jar and jzmq.lib, jzmq.dll
-```
-D:\temp\JZMQ\jzmq\jzmq-jni\build64>nmake
-Microsoft (R) Program Maintenance Utility Version 14.00.24210.0
-Copyright (C) Microsoft Corporation.  All rights reserved.
+Set up *vcpkg* as described in [Tutorial: Install and use packages with CMake](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started)
+then install the *ZeroMQ* vcpkg package:
 
-[ 10%] Generating config.hpp
-[ 20%] Generating org/zeromq/ZMQ.class, org/zeromq/Utils.class, org/zeromq/ZMQ$$Context.class, org/zeromq/ZMQ$$Socket.class, org/zeromq/ZMQ$$PollItem.class, org/zeromq/ZMQ$$Poller.class, org/zeromq/ZM
-Q$$Error.class, org/zeromq/ZMQException.class, org/zeromq/ZMQQueue.class, org/zeromq/ZMQForwarder.class, org/zeromq/ZMQStreamer.class, org/zeromq/EmbeddedLibraryTools.class, org/zeromq/App.class, org/
-zeromq/ZContext.class, org/zeromq/ZDispatcher.class, org/zeromq/ZDispatcher$$1.class, org/zeromq/ZDispatcher$$SocketDispatcher$$1.class, org/zeromq/ZDispatcher$$SocketDispatcher$$2.class, org/zeromq/Z
-Dispatcher$$SocketDispatcher$$ZMessageBuffer.class, org/zeromq/ZDispatcher$$SocketDispatcher.class, org/zeromq/ZDispatcher$$ZMessageHandler.class, org/zeromq/ZDispatcher$$ZSender.class, org/zeromq/ZFr
-ame.class, org/zeromq/ZMsg.class, org/zeromq/ZLoop.class, org/zeromq/ZLoop$$IZLoopHandler.class, org/zeromq/ZLoop$$SPoller.class, org/zeromq/ZLoop$$STimer.class, org/zeromq/ZThread.class, org/zeromq/Z
-Thread$$IAttachedRunnable.class, org/zeromq/ZThread$$IDetachedRunnable.class, org/zeromq/ZThread$$ShimThread.class
-Note: Some input files use or override a deprecated API.
-Note: Recompile with -Xlint:deprecation for details.
-[ 30%] Generating org_zeromq_ZMQ.h, org_zeromq_ZMQ_Error.h, org_zeromq_ZMQ_Context.h, org_zeromq_ZMQ_Socket.h, org_zeromq_ZMQ_PollItem.h, org_zeromq_ZMQ_Poller.h
-[ 40%] Generating lib/zmq.jar
-Scanning dependencies of target jzmq
-[ 40%] Generating org/zeromq/ZMQ.class, org/zeromq/Utils.class, org/zeromq/ZMQ$$Context.class, org/zeromq/ZMQ$$Socket.class, org/zeromq/ZMQ$$PollItem.class, org/zeromq/ZMQ$$Poller.class, org/zeromq/ZM
-Q$$Error.class, org/zeromq/ZMQException.class, org/zeromq/ZMQQueue.class, org/zeromq/ZMQForwarder.class, org/zeromq/ZMQStreamer.class, org/zeromq/EmbeddedLibraryTools.class, org/zeromq/App.class, org/
-zeromq/ZContext.class, org/zeromq/ZDispatcher.class, org/zeromq/ZDispatcher$$1.class, org/zeromq/ZDispatcher$$SocketDispatcher$$1.class, org/zeromq/ZDispatcher$$SocketDispatcher$$2.class, org/zeromq/Z
-Dispatcher$$SocketDispatcher$$ZMessageBuffer.class, org/zeromq/ZDispatcher$$SocketDispatcher.class, org/zeromq/ZDispatcher$$ZMessageHandler.class, org/zeromq/ZDispatcher$$ZSender.class, org/zeromq/ZFr
-ame.class, org/zeromq/ZMsg.class, org/zeromq/ZLoop.class, org/zeromq/ZLoop$$IZLoopHandler.class, org/zeromq/ZLoop$$SPoller.class, org/zeromq/ZLoop$$STimer.class, org/zeromq/ZThread.class, org/zeromq/Z
-Thread$$IAttachedRunnable.class, org/zeromq/ZThread$$IDetachedRunnable.class, org/zeromq/ZThread$$ShimThread.class
-Note: Some input files use or override a deprecated API.
-Note: Recompile with -Xlint:deprecation for details.
-[ 40%] Generating org_zeromq_ZMQ.h, org_zeromq_ZMQ_Error.h, org_zeromq_ZMQ_Context.h, org_zeromq_ZMQ_Socket.h, org_zeromq_ZMQ_PollItem.h, org_zeromq_ZMQ_Poller.h
-[ 50%] Building CXX object CMakeFiles/jzmq.dir/src/main/c++/Context.cpp.obj
-Context.cpp
-[ 60%] Building CXX object CMakeFiles/jzmq.dir/src/main/c++/Poller.cpp.obj
-Poller.cpp
-D:\temp\JZMQ\jzmq\jzmq-jni\src\main\c++\Poller.cpp(76): warning C4244: '=': conversion from 'jint' to 'short', possible loss of data
-[ 70%] Building CXX object CMakeFiles/jzmq.dir/src/main/c++/Socket.cpp.obj
-Socket.cpp
-D:\temp\JZMQ\jzmq\jzmq-jni\src\main\c++\Socket.cpp(266): warning C4267: 'argument': conversion from 'size_t' to 'jsize', possible loss of data
-D:\temp\JZMQ\jzmq\jzmq-jni\src\main\c++\Socket.cpp(272): warning C4267: 'argument': conversion from 'size_t' to 'jsize', possible loss of data
-D:\temp\JZMQ\jzmq\jzmq-jni\src\main\c++\Socket.cpp(847): warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data
-D:\temp\JZMQ\jzmq\jzmq-jni\src\main\c++\Socket.cpp(875): warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data
-[ 80%] Building CXX object CMakeFiles/jzmq.dir/src/main/c++/util.cpp.obj
-util.cpp
-[ 90%] Building CXX object CMakeFiles/jzmq.dir/src/main/c++/ZMQ.cpp.obj
-ZMQ.cpp
-[100%] Linking CXX shared library lib\jzmq.dll
-   Creating library lib\jzmq.lib and object lib\jzmq.exp
-   Creating library lib\jzmq.lib and object lib\jzmq.exp
-[100%] Built target jzmq
 ```
+vcpkg install zeromq
+```
+
+Clone this repository and go to the jzmq-jni directory:
+
+```
+cd jmzq-jni
+```
+
+Configure the build with CMake using the toolchain provided by vcpkg after finding its path:
+
+```
+cmake -B build -S . "-DCMAKE_TOOLCHAIN_FILE=\path\to\vcpkg\vcpkg\scripts\buildsystems\vcpkg.cmake"
+```
+
+Build the library:
+
+```
+cmake --build build --config Release
+```
+
+The file jzmq.dll should be present in *build\lib\Release* along with the ZeroMQ dll provided by vcpkg.
+To run a Java program using JZMQ, set the *%Path%* so that the JZMQ and ZeroMQ dlls are found.
+
 
 Avoiding JNI
 ------------

--- a/jzmq-jni/CMakeLists.txt
+++ b/jzmq-jni/CMakeLists.txt
@@ -1,17 +1,22 @@
 # CMake build script for ØMQ Java bindings on Windows
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.20)
 
 project (JZMQ)
 find_package (Java REQUIRED)
 find_package (JNI REQUIRED)
+find_package (ZeroMQ QUIET)
 
+if(NOT ZeroMQ_FOUND)
+  message(STATUS "ZeroMQ was not found by package")
+endif()
 
 set(ZMQ_C_INCLUDE_PATH "" CACHE PATH "Path to ZMQ Header files")
 set(ZMQ_C_LIB_PATH "" CACHE PATH "Path to ZMQ library")
 
-find_program (JNI_JAVAH
-  NAMES javah
+# Search for javac which replaces javah
+find_program (JNI_JAVAC
+  NAMES javac
 	HINTS ${_JAVA_HINTS}
 	PATHS ${_JAVA_PATHS}
 )
@@ -73,11 +78,14 @@ set(java-sources
 set(java-classes
 	org/zeromq/ZMQ.class
 	org/zeromq/Utils.class
-	org/zeromq/ZMQ$$Context.class
-	org/zeromq/ZMQ$$Socket.class
-	org/zeromq/ZMQ$$PollItem.class
-	org/zeromq/ZMQ$$Poller.class
-	org/zeromq/ZMQ$$Error.class				
+	org/zeromq/ZMQ$Context.class
+	org/zeromq/ZMQ$Curve$KeyPair.class
+	org/zeromq/ZMQ$Curve.class
+	org/zeromq/ZMQ$Socket.class
+	org/zeromq/ZMQ$PollItem.class
+	org/zeromq/ZMQ$Poller.class
+	org/zeromq/ZMQ$Error.class
+	org/zeromq/ZMQ$Event.class
 	org/zeromq/ZMQException.class
 	org/zeromq/ZMQQueue.class
 	org/zeromq/ZMQForwarder.class
@@ -86,23 +94,22 @@ set(java-classes
 	org/zeromq/App.class
 	org/zeromq/ZContext.class
 	org/zeromq/ZDispatcher.class
-	org/zeromq/ZDispatcher$$1.class
-	org/zeromq/ZDispatcher$$SocketDispatcher$$1.class
-	org/zeromq/ZDispatcher$$SocketDispatcher$$2.class
-	org/zeromq/ZDispatcher$$SocketDispatcher$$ZMessageBuffer.class
-	org/zeromq/ZDispatcher$$SocketDispatcher.class
-	org/zeromq/ZDispatcher$$ZMessageHandler.class
-	org/zeromq/ZDispatcher$$ZSender.class
+	org/zeromq/ZDispatcher$SocketDispatcher$1.class
+	org/zeromq/ZDispatcher$SocketDispatcher$2.class
+	org/zeromq/ZDispatcher$SocketDispatcher$ZMessageBuffer.class
+	org/zeromq/ZDispatcher$SocketDispatcher.class
+	org/zeromq/ZDispatcher$ZMessageHandler.class
+	org/zeromq/ZDispatcher$ZSender.class
 	org/zeromq/ZFrame.class
 	org/zeromq/ZMsg.class
 	org/zeromq/ZLoop.class
-	org/zeromq/ZLoop$$IZLoopHandler.class
-	org/zeromq/ZLoop$$SPoller.class
-	org/zeromq/ZLoop$$STimer.class
+	org/zeromq/ZLoop$IZLoopHandler.class
+	org/zeromq/ZLoop$SPoller.class
+	org/zeromq/ZLoop$STimer.class
 	org/zeromq/ZThread.class
-	org/zeromq/ZThread$$IAttachedRunnable.class
-	org/zeromq/ZThread$$IDetachedRunnable.class
-	org/zeromq/ZThread$$ShimThread.class
+	org/zeromq/ZThread$IAttachedRunnable.class
+	org/zeromq/ZThread$IDetachedRunnable.class
+	org/zeromq/ZThread$ShimThread.class
 )
 set(javah-headers
 	org_zeromq_ZMQ.h
@@ -160,10 +167,10 @@ list(APPEND sources ${CMAKE_CURRENT_BINARY_DIR}/config.hpp)
 
 add_custom_command(
 	OUTPUT ${javah-headers}
-	COMMAND ${JNI_JAVAH}
-	ARGS	-jni
-		-classpath ${CMAKE_CURRENT_BINARY_DIR}
-		org.zeromq.ZMQ
+	COMMAND ${JNI_JAVAC}
+	ARGS ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java/org/zeromq/ZMQ.java
+	     -cp ${CMAKE_CURRENT_BINARY_DIR}
+	     -h ${CMAKE_CURRENT_BINARY_DIR}
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 	DEPENDS ${java-classes}
 )
@@ -200,7 +207,13 @@ list(APPEND sources lib/zmq.jar)
 # output
 
 add_library(jzmq SHARED ${sources})
-target_link_libraries(jzmq libzmq.lib)
+
+if(ZeroMQ_FOUND)
+  target_link_libraries(jzmq PRIVATE libzmq)
+else()
+  target_link_libraries(jzmq libzmq.lib)
+endif()
+
 
 set(docs
     AUTHORS


### PR DESCRIPTION
The file jzmq-jni/CMakeLists.txt is very old and does not allow to use vcpkg properly. Moreover it is not compatible with current Java SDKs anymore.

I've updated the file and modified the README so that it becomes easy to compile jzmq using Visual C++ compiler with vcpkg.